### PR TITLE
link for find-help was broken

### DIFF
--- a/_includes/carousel.html
+++ b/_includes/carousel.html
@@ -55,7 +55,7 @@
       <a
       class="btn btn-primary inverted-dark-purple"
       role="button"
-      href="/find-help"
+      href="/find-help.html"
       >
         VIEW ALL RESOURCES
       </a>

--- a/_includes/main-title.html
+++ b/_includes/main-title.html
@@ -21,7 +21,7 @@
         <a
             class="btn btn-primary dark-purple"
             role="button"
-            href="/find-help">
+            href="/find-help.html">
             I NEED HELP
           </a>
           <a

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -15,7 +15,7 @@
               <a class="navigation-link home-find-help-get-i" href="/">home</a>
             </li>
             <li class="nav-item">
-              <a class="navigation-link home-find-help-get-i" href="/find-help">find help</a>
+              <a class="navigation-link home-find-help-get-i" href="/find-help.html">find help</a>
             </li>
             <li class="nav-item">
               <a class="navigation-link home-find-help-get-i" href="https://airtable.com/shrDrTCZQmDlCN8sg" target="_blank">


### PR DESCRIPTION
mediatemple the way it's set up needs us to specify ".html" at the end of links if they're to html pages.