### PR TITLE
fixes #91 - find-help header looks better on mobile

### DIFF
--- a/_includes/find-help/main-title.html
+++ b/_includes/find-help/main-title.html
@@ -1,6 +1,6 @@
 <div class="shadow-sm p-3 mb-2 bg-white rounded">
   <div class="row">
-    <div class="col-1">
+    <div class="col-md-12">
       <div class="float-left">
         <button
           class="navbar-toggler collapsed hamburger-background light-purple-background align-left"
@@ -17,25 +17,31 @@
           <span class="icon-bar bottom-bar color-black"></span>
         </button>
       </div>
+      <div class="float-right">
+        <img
+          class="cbus-logo-square img-fluid"
+          src="assets/img/cscbus_logo_square.svg"
+        />
+      </div>
     </div>
-    <div class="col-7">
+  </div>
+  <div class="row">
+    <div class="col-md-5 offset-md-1">
       <h1 class="page-title">
         Find Help
       </h1>
       <p class="page-lead m-0">
-        Find the help you need in <span class="highlight">Columbus</span><br/>
+        Find the help you need in <span class="highlight">Columbus</span><br />
         We're all in this together
       </p>
     </div>
-    <div class="col-4">
-      <div class="float-right">
-        <a class="mt-4 btn btn-outline-primary btn-lg dark-bg" href="mailto:hello@cantstopcolumbus.com?Subject=Submit%20a%20Resource">
-          <i class="fa fa-envelope-square"></i>&nbsp;Submit a Resource</a>
-        <img
-          class="cbus-logo-square img-fluid ml-3"
-          src="assets/img/cscbus_logo_square.svg"
-        />
-      </div>
+    <div class="col-md-5 m-2">
+      <a
+        class="btn btn-outline-primary btn-lg dark-bg"
+        href="mailto:hello@cantstopcolumbus.com?Subject=Submit%20a%20Resource"
+      >
+        <i class="fa fa-envelope-square"></i>&nbsp;Submit a Resource</a
+      >
     </div>
   </div>
 </div>


### PR DESCRIPTION
fixes issue #91 - find-help header looks bad on mobile. @slythr I am struggling to get the site to look *exactly* like the mocks, but this is pretty close.