### PR TITLE
GitHub actions to build and deploy

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -10,8 +10,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-      with:
-        fetch-depth: 2
 
     - name: Build the site in the jekyll/builder container
       run: |

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -3,8 +3,6 @@ name: Jekyll site CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -18,10 +18,10 @@ jobs:
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
         jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
-
-    - name: Deploy
-      uses: SamKirkland/FTP-Deploy-Action@2.0.0
-      env:
+      
+    - name: FTP Deploy
+      uses: SamKirkland/FTP-Deploy-Action@3.0.0
+      with:
         ftp-server: 205.186.128.139
         ftp-username: developer@cantstopcolumbus.com
         ftp-password: ${{ secrets.FTP_PASSWORD }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,32 @@
+name: Jekyll site CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 2
+
+    - name: Build the site in the jekyll/builder container
+      run: |
+        docker run \
+        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+
+    - name: Deploy
+      uses: SamKirkland/FTP-Deploy-Action@2.0.0
+      env:
+        ftp-server: 205.186.128.139
+        ftp-username: developer@cantstopcolumbus.com
+        ftp-password: ${{ secrets.FTP_PASSWORD }}
+        local-dir: ./_site/
+        remote-root:  /
+        git-ftp-args: --dry-run


### PR DESCRIPTION
this uses a few GitHub actions to do build with jekyll and then deploy via FTP to media temple. Theoretically it will do this when someone pushes a PR to master.

fixes #98 - spike to implement GitHub actions.

as of now, just does a dry run for publishing. will change to "real" FTP after i see it run a few times.