### PR TITLE
remove URL for employ ohio now

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -57,7 +57,7 @@
     - news
 
 - logo: employ-ohio-now.svg
-  link: https://5e7cff6e7313380211c8e562--employohionow.netlify.com/#/
+  link: #
   title: Employ Ohio Now
   description: Find jobs and fill talent needs created by COVID-19 
   tags: 


### PR DESCRIPTION
fixes #130 - by request from Derek DeHart and Lee Salisbury, the link for the Netlify site is not quite ready for prime time, so we need to remove the link for now.