### PR TITLE
fix: #108 | Add max-width to flagged logos

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -26,6 +26,7 @@
   link: https://nextdoormunch.com/
   title: Next Door Munch
   description: Get groceries delivered by neighbors, for neighbors
+  limit-width: true
   tags:
     - food
 
@@ -67,5 +68,6 @@
   link: https://jobseeker.ohiomeansjobs.monster.com/
   title: Ohio Means Jobs
   description: Job listings and career-building resources
+  limit-width: true
   tags: 
     - employment

--- a/_includes/find-help/project-card.html
+++ b/_includes/find-help/project-card.html
@@ -1,4 +1,4 @@
-<div class="col-sm-3">
+<div class="col-sm-6 col-lg-3">
   <div class="card my-2">
     <div class="d-flex p-1 h-100">
     <img
@@ -6,7 +6,11 @@
       style="background-color: {{ include.proj.backgroundcolor }};"
     {% endif %}
       src="assets/img/UX/projects/{{ include.proj.logo }}"
+    {% if include.proj.limit-width %}
+      class="p-2 card-img-top limit-width"
+    {% else %}
       class="p-2 card-img-top align-self-center"
+    {% endif %}
     />
     </div>
     <div class="card-body">

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -29,6 +29,15 @@ body {
 #project-cards .row {
   display: flex;
   flex-wrap: wrap;
+
+  img {
+    &.limit-width {
+      display: block;
+      max-height: 180px;
+      max-width: 180px;
+      margin: auto;
+    }
+  }
 }
 
 #project-cards .row > div[class*='col-'] {


### PR DESCRIPTION
Sets a max-width and max-height to 180px on project with a flag of `limit-width`. Also fixes a bug with project card spacing at tablet level. 

Not the most elegant solution but works for now. 