### PR TITLE
fix: Nav link text size

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -123,10 +123,8 @@ div.jumbotron {
   font-size: 2rem;
 
   @media #{$break-tablet-up} {
-    font-size: 60px;
+    font-size: 3rem;
     font-weight: 500;
-    letter-spacing: 0.43px;
-    line-height: 100px;
   }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -209,6 +209,8 @@ h1 {
 
 .navigation-menu {
   margin-top: -22px;
+  max-height: 95vh;
+  overflow-y: auto;
   padding-left: 50px;
 }
 


### PR DESCRIPTION
Updates the link text sizes and adds a scroll bar in the event that the device height is smaller than the nav