### PR TITLE
Impact to category

### DIFF
--- a/_includes/find-help/projects.html
+++ b/_includes/find-help/projects.html
@@ -7,20 +7,20 @@
       aria-labelledby="all-tab"
     >
       <div class="row">
-        <project-card v-for="proj in allProjects()" v-bind:project="proj">
+        <project-card v-for="proj in allProjects" v-bind:project="proj">
         </project-card>
        </div>
     </div>
     <div
-      v-for="impact in projectImpacts()"
+      v-for="category in projectCategories"
       class="tab-pane"
-      :id="impact"
+      :id="category"
       role="tabpanel"
-      :aria-labelledby="impact + '-tab'"
+      :aria-labelledby="category + '-tab'"
     >
       <div class="row">
         <!-- only include projects that match the tab in each tab pane -->
-        <project-card v-for="proj in matchTab(impact)" v-bind:project="proj">
+        <project-card v-for="proj in projectsForCategory(category)" v-bind:project="proj">
         </project-card>
       </div>
     </div>

--- a/_includes/find-help/tabs.html
+++ b/_includes/find-help/tabs.html
@@ -11,7 +11,7 @@
         ALL
       </a>
     </li>
-    <li v-for="impact in projectImpacts()" class="nav-item border-control">
+    <li v-for="impact in projectCategories" class="nav-item border-control">
       <a
         class="nav-link"
         data-toggle="pill"

--- a/_includes/index/carousel2.html
+++ b/_includes/index/carousel2.html
@@ -7,7 +7,7 @@
   </br>
   <div class="col-md-12">
     <div class="card-deck" id="carousel2">
-      <project-card v-for="proj in carouselProjects()" v-bind:project="proj">
+      <project-card v-for="proj in carouselProjects" v-bind:project="proj">
       </project-card>
     </div>
   </div>

--- a/_includes/partners/ally.html
+++ b/_includes/partners/ally.html
@@ -1,5 +1,5 @@
 <div class="row artisan-ally-bootstrap-row" id="ally">
-  <div v-for="partner in partnerFilter('PubAlly')" class="artisan-ally-bootstrap-col" >
+  <div v-for="partner in allies" class="artisan-ally-bootstrap-col" >
     <partner-card v-bind:item=partner></partner-card>
   </div>
 </div>

--- a/_includes/partners/angel.html
+++ b/_includes/partners/angel.html
@@ -1,5 +1,5 @@
 <div class="row artisan-ally-bootstrap-row">
-  <div v-for="partner in partnerFilter('PubAngel')" class="artisan-ally-bootstrap-col" >
+  <div v-for="partner in angels" class="artisan-ally-bootstrap-col" >
     <partner-card v-bind:item=partner></partner-card>
   </div>
 </div>

--- a/_includes/partners/community.html
+++ b/_includes/partners/community.html
@@ -1,5 +1,5 @@
 <div class="row artisan-ally-bootstrap-row">
-  <div v-for="partner in partnerFilter('PubCommPartner')" class="artisan-ally-bootstrap-col" >
+  <div v-for="partner in communityPartners" class="artisan-ally-bootstrap-col" >
     <partner-card v-bind:item=partner></partner-card>
   </div>
 </div>

--- a/_includes/partners/featured.html
+++ b/_includes/partners/featured.html
@@ -1,5 +1,5 @@
 <div class="row artisan-featured-bootstrap-row">
-  <div v-for="partner in partnerFilter('PubFeatured')" class="artisan-featured-bootstrap-col" >
+  <div v-for="partner in featuredPartners" class="artisan-featured-bootstrap-col" >
     <partner-card v-bind:item=partner></partner-card>
   </div>
 </div>

--- a/_includes/partners/kind.html
+++ b/_includes/partners/kind.html
@@ -1,5 +1,5 @@
 <div class="row artisan-ally-bootstrap-row">
-  <div v-for="partner in partnerFilter('PubInKind')" class="artisan-ally-bootstrap-col" >
+  <div v-for="partner in inKindPartners" class="artisan-ally-bootstrap-col" >
     <partner-card v-bind:item=partner></partner-card>
   </div>
 </div>

--- a/_includes/partners/professional.html
+++ b/_includes/partners/professional.html
@@ -1,5 +1,5 @@
 <div class="row artisan-ally-bootstrap-row">
-  <div v-for="partner in partnerFilter('PubProfPartner')" class="artisan-ally-bootstrap-col" >
+  <div v-for="partner in professionalPartners" class="artisan-ally-bootstrap-col" >
     <partner-card v-bind:item=partner></partner-card>
   </div>
 </div>

--- a/assets/js/cantstopcbus-vue.js
+++ b/assets/js/cantstopcbus-vue.js
@@ -26,7 +26,7 @@ let transformProject = (project) => {
     website: project["Project Website"],
     text: project["Project Public Desc"],
     title: project.Title,
-    impact: project["Primary Impact Area"][0]["Impact Area"]
+    category: project.Category[0].Category
   }
   let defaultLogo = "/assets/img/UX/cscbus_logo_square.svg"
   retval.logo = project.hasOwnProperty("Project Logo")
@@ -43,31 +43,33 @@ var cantstopcbus = new Vue({
     partners: [],
   },
   methods: {
-    matchTab: function (tabName) {
-      return this.allProjects().filter((project) => project.impact === tabName)
+    projectsForCategory: function (category) {
+      return this.allProjects.filter((project) => project.category === category)
     },
     partnerFilter: function (attribute) {
-      return this.allPartners().filter((partner) => partner[attribute] === true && partner.Logo)
-    },
-    projectImpacts: function () {
-      return this.allProjects()
-        .map((project) => project.impact)
-        .filter((value, idx, self) => self.indexOf(value) === idx)
-        .sort((a, b) => a >= b)
+      return this.allPartners.filter((partner) => partner[attribute] === true && partner.Logo)
     },
     carouselProjects: function () {
-      return shuffle(this.allProjects()).slice(0, 4)
+      return shuffle(this.allProjects).slice(0, 4)
     },
-    allPartners: function () {
-      return this.partners
+  },
+  computed: {
+    projectCategories: function () {
+      return this.allProjects
+        .map((project) => project.category)
+        .filter((value, idx, self) => self.indexOf(value) === idx)
+        .sort((a,b) => a >= b)
     },
     allProjects: function () {
       return this.projects.map((project) => {
         return transformProject(project)
       })
+    },
+    allPartners: function () {
+      return this.partners
     }
   },
-  created: function () {
+  mounted () {
     axios
       .get(
         "https://wduc7ys73l.execute-api.us-east-1.amazonaws.com/dev/projects"

--- a/assets/js/cantstopcbus-vue.js
+++ b/assets/js/cantstopcbus-vue.js
@@ -67,6 +67,24 @@ var cantstopcbus = new Vue({
     },
     allPartners: function () {
       return this.partners
+    },
+    professionalPartners: function () {
+      return this.partnerFilter("PubProfPartner")
+    },
+    allies: function () {
+      return this.partnerFilter("PubAlly")
+    },
+    angels: function () {
+      return this.partnerFilter("PubAngel")
+    },
+    communityPartners: function () {
+      return this.partnerFilter("PubCommPartner")
+    },
+    featuredPartners: function () {
+      return this.partnerFilter("PubFeatured")
+    },
+    inKindPartners: function () {
+      return this.partnerFilter("PubInKind")
     }
   },
   mounted () {

--- a/assets/js/cantstopcbus-vue.js
+++ b/assets/js/cantstopcbus-vue.js
@@ -49,11 +49,11 @@ var cantstopcbus = new Vue({
     partnerFilter: function (attribute) {
       return this.allPartners.filter((partner) => partner[attribute] === true && partner.Logo)
     },
+  },
+  computed: {
     carouselProjects: function () {
       return shuffle(this.allProjects).slice(0, 4)
     },
-  },
-  computed: {
     projectCategories: function () {
       return this.allProjects
         .map((project) => project.category)


### PR DESCRIPTION
fixes #206 

go back to using categories instead of impacts, because of the hit on UX caused by so many categories. Looks much much better now:

![image](https://user-images.githubusercontent.com/221065/80293114-7df7f600-872a-11ea-8fc8-b9d49bd2c08b.png)
