### PR TITLE
fix: Issue 212 | Make partner portal mobile again

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
       <span class="icon-bar bottom-bar color-black"></span>
     </button>
   </div>
-  <div class="order-3 order-md-2 main-cta-container">
+  <div class="order-3 order-md-2 col-sm-12 col-md-8 pl-0 main-cta-container">
     {{ include.between }}
   </div>
   <div class="order-2 order-md-3">

--- a/_includes/partners/main-title.html
+++ b/_includes/partners/main-title.html
@@ -1,32 +1,9 @@
 <!-- Use this commented out section once more content goes under the partners h2 -->
-<!-- {% capture between_content %}
+{% capture between_content %}
 <div class="title-content col-md-8">
   <h1>Partners</h1>
 </div>
 {% endcapture %}
 <div class="jumbotron background-white">
   {% include nav.html between=between_content %}
-</div> -->
-<div class="jumbotron background-white header-tile">
-  <div class="row m-0 justify-content-between">
-    <div class="order-1 order-md-1">
-      <button class="navbar-toggler collapsed hamburger-background light-purple-background align-left" type="button"
-        data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault"
-        aria-expanded="false" aria-label="Toggle navigation" onclick="on()">
-        <span class="icon-bar top-bar color-black"></span>
-        <span class="icon-bar middle-bar color-black"></span>
-        <span class="icon-bar bottom-bar color-black"></span>
-      </button>
-    </div>
-    <div class="order-3 order-md-2 col-sm-12 col-md-8 main-cta-container">
-      <div class="title-content">
-        <h1>Partners</h1>
-      </div>
-    </div>
-    <div class="order-2 order-md-3">
-      <a href="/">
-          <img src="{{ 'assets/img/UX/cscbus_logo_square.svg' | relative_url }}" align="right" style="height: 75px;" alt="CSC Home" />
-        </a>
-    </div>
-  </div>
 </div>

--- a/_includes/partners/main-title.html
+++ b/_includes/partners/main-title.html
@@ -1,17 +1,32 @@
-{% capture between_content %}
+<!-- Use this commented out section once more content goes under the partners h2 -->
+<!-- {% capture between_content %}
 <div class="title-content col-md-8">
   <h1>Partners</h1>
-<!--       <h4>TBD</h4>
-  <div class="d-flex help-button-group">
-    <a  class="btn btn-primary btn-lg dark-purple"
-        role="button"
-        href="" target="_blank"
-        >
-        <i class="fa fa-external-link-alt"></i>&nbsp;Become an ally
-      </a>
-  </div> -->
 </div>
 {% endcapture %}
 <div class="jumbotron background-white">
   {% include nav.html between=between_content %}
+</div> -->
+<div class="jumbotron background-white header-tile">
+  <div class="row m-0 justify-content-between">
+    <div class="order-1 order-md-1">
+      <button class="navbar-toggler collapsed hamburger-background light-purple-background align-left" type="button"
+        data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault"
+        aria-expanded="false" aria-label="Toggle navigation" onclick="on()">
+        <span class="icon-bar top-bar color-black"></span>
+        <span class="icon-bar middle-bar color-black"></span>
+        <span class="icon-bar bottom-bar color-black"></span>
+      </button>
+    </div>
+    <div class="order-3 order-md-2 col-sm-12 col-md-8 main-cta-container">
+      <div class="title-content">
+        <h1>Partners</h1>
+      </div>
+    </div>
+    <div class="order-2 order-md-3">
+      <a href="/">
+          <img src="{{ 'assets/img/UX/cscbus_logo_square.svg' | relative_url }}" align="right" style="height: 75px;" alt="CSC Home" />
+        </a>
+    </div>
+  </div>
 </div>

--- a/_includes/partners/main-title.html
+++ b/_includes/partners/main-title.html
@@ -1,4 +1,3 @@
-<!-- Use this commented out section once more content goes under the partners h2 -->
 {% capture between_content %}
 <div class="title-content col-md-8">
   <h1>Partners</h1>


### PR DESCRIPTION
desktop
<img width="450" alt="Screen Shot 2020-04-28 at 8 28 24 AM" src="https://user-images.githubusercontent.com/18721340/80487112-4788c980-892a-11ea-8998-972ea321fd72.png">
mobile:
<img width="450" alt="Screen Shot 2020-04-28 at 8 28 35 AM" src="https://user-images.githubusercontent.com/18721340/80487114-48b9f680-892a-11ea-8346-18b57597343c.png">
