### PR TITLE
Index stop text overrun

### DIFF
--- a/_includes/index/carousel2.html
+++ b/_includes/index/carousel2.html
@@ -6,31 +6,28 @@
   </div>
   </br>
   <div class="col-md-12">
-    <div class="card-deck" id="carousel2">
+    <div class="card-group" id="carousel2">
       <project-card v-for="proj in carouselProjects" v-bind:project="proj">
       </project-card>
     </div>
   </div>
   <div class="row">
-    <div class="col-md-12 my-2">
+    <div class="col-12 my-2">
       <a
-      class="btn btn-secondary btn-lg"
+      class="btn btn-secondary btn-lg m-1"
       role="button"
       href="/find-help.html"
       >
         VIEW ALL RESOURCES
       </a>
-      &nbsp;&nbsp;
       <a
-      class="btn btn-secondary btn-lg"
+      class="btn btn-secondary btn-lg m-1"
       role="button"
       target="_blank"
       href="https://sites.google.com/view/csc-project-central"
       >
         VIEW PROJECT CENTRAL SITE
       </a>
-      <!-- <a class="mt-4 btn btn-outline-primary btn-lg dark-bg" href="mailto:hello@cantstopcolumbus.com?Subject=Submit%20a%20Resource">
-        <i class="fa fa-envelope-square"></i>&nbsp;Submit a Resource</a> -->
     </div>
   </div>
 </div>

--- a/_includes/index/carousel2.html
+++ b/_includes/index/carousel2.html
@@ -11,17 +11,19 @@
       </project-card>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 my-2">
+  <div class="row justify-items-center">
+    <div class="col-lg-6">
       <a
-      class="btn btn-secondary btn-lg m-1"
+      class="btn btn-secondary btn-lg btn-block m-1"
       role="button"
       href="/find-help.html"
       >
         VIEW ALL RESOURCES
       </a>
+    </div>
+    <div class="col-lg-6">
       <a
-      class="btn btn-secondary btn-lg m-1"
+      class="btn btn-secondary btn-lg btn-block m-1"
       role="button"
       target="_blank"
       href="https://sites.google.com/view/csc-project-central"

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -76,16 +76,18 @@ Vue.component("project-card", {
   props: ["project"],
   delimiters: ["{$", "$}"],
   template: `
-    <div class="card my-2 col-sm-6 col-lg-3">
-      <div style="height: 50%; padding-top:2em;">
-        <div class="d-flex p-1 h-100">
-          <img :src="project.logo" class="p-2 card-img-top align-self-center limit-width"/>
+    <div class="col-sm-6 col-lg-3 d-flex align-items-stretch">
+      <div class="card my-1">
+        <div class="row h-100 align-items-center">
+          <div class="col-sm-12">
+            <img :src="project.logo" class="card-img-top"/>
+          </div>
         </div>
         <div class="card-body">
           <a :href="project.website" target="_blank">
             <h5 class="card-title">{$ project.title $}</h5>
           </a>
-          <p style="padding-bottom: 2em;" class="card-text">{$ project.text $}</p>
+          <p class="card-text">{$ project.text $}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The list of projects on the home page acts funny when the images are too large for their containers. This PR doesn't necessarily align the text & titles, but the text no longer overruns the borders of the cards and the images are vertically aligned within their rows at all display sizes.