### PR TITLE
use different envelope icon

### DIFF
--- a/_includes/find-help/main-title.html
+++ b/_includes/find-help/main-title.html
@@ -10,7 +10,7 @@
       class="btn btn-outline-primary btn-lg dark-bg"
       href="mailto:hello@cantstopcolumbus.com?Subject=Submit%20a%20Resource"
     >
-      <i class="fa fa-envelope-square"></i>&nbsp;Submit a Resource
+      <i class="fas fa-envelope"></i>&nbsp;Submit a Resource
     </a>
   </div>
 </div>


### PR DESCRIPTION
use the fa-envelope icon instead of the fa-envelope-square icon. looks better. closes #211 