### PR TITLE
Fix for main-page Contact Us flex rows

### DIFF
--- a/_includes/index/contact-us.html
+++ b/_includes/index/contact-us.html
@@ -1,7 +1,7 @@
 <div class="jumbotron">
     <h2>Contact <span class="purple-font">US</span></h2>
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-5">
             <h3>Looking to volunteer?</h3>
             <a
                 class="btn btn-secondary" role="button"
@@ -9,13 +9,13 @@
                 I WANT TO HELP
             </a>
         </div>
-        <div class="col-md-6 d-flex flex-column contact-us-links">
+        <div class="col-md-7 d-flex flex-column contact-us-links">
             <div class="d-flex flex-row align-items-center">
                 <a
                     class="btn btn-secondary mr-3"
                     role="button" href="mailto:hello@cantstopcolumbus.com?Subject=Submit%20a%20Resource"
                     target="_blank">
-                        <img src="../assets/img/UX/icons/ico_mail.svg">
+                    <i class="fas fa-envelope"></i>
                 </a>
                 <h2 class="purple-font small-phone" style="text-align:left;">hello@cantstopcolumbus.com</span></h2>
             </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -262,7 +262,7 @@ h1 {
   }
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 991px) {
   .small-phone {
     font-size: 20px;
     vertical-align: middle;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -262,7 +262,7 @@ h1 {
   }
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 1000px) {
   .small-phone {
     font-size: 20px;
     vertical-align: middle;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -254,11 +254,21 @@ h1 {
 
 @media only screen and (max-width: 768px) {
   .small-phone {
-    font-size: 14px;
+    font-size: 18px;
     vertical-align: middle;
   }
   .small-phone-div {
     margin-top: .1em;
+  }
+}
+
+@media only screen and (max-width: 900px) {
+  .small-phone {
+    font-size: 20px;
+    vertical-align: middle;
+  }
+  .small-phone-div {
+    margin-top: .2em;
   }
 }
 


### PR DESCRIPTION
## Fixes

- Created 'medium phone' CSS class for devices that are larger than 768px but smaller than 991px
- Replaced original icon in `contact-us.html` for email and reset the flex sizes from `col-5` to `col-7` for email while setting `Looking to Volunteer` section is set from `col-7` to `col-5`